### PR TITLE
在前端加入auth模块

### DIFF
--- a/src/components/Header/index.vue
+++ b/src/components/Header/index.vue
@@ -28,9 +28,9 @@
               </div>
           </div>
           <div class="log-box">
-            <span><router-link to="/register">注册</router-link></span>
+            <span><a href="http://localhost:8080/accounts/signup">注册</a></span>
             |
-            <span><router-link to="/login">登陆</router-link></span>
+            <span><a href="http://localhost:8080/accounts/login">登陆</a></span>
           </div>
         </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -5,9 +5,13 @@ import App from './App'
 import router from './router'
 import mavonEditor from 'mavon-editor'
 import 'mavon-editor/dist/css/index.css'
+import auth from './utils/auth'
 
 Vue.config.productionTip = false
 Vue.use(mavonEditor)
+
+auth.checkAuth();
+console.log(auth.getAuthHeader());
 
 /* eslint-disable no-new */
 new Vue({

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,16 +30,6 @@ export default new Router({
       component: Detail
     },
     {
-      path: '/register',
-      name: 'register',
-      component: Register
-    },
-    {
-      path: '/login',
-      name: 'login',
-      component: Login
-    },
-    {
       path: '/profile',
       name: 'profile',
       component: Profile,

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,37 @@
+export default {
+  user: {
+    authenticated: false
+  },
+
+  getJwtFromCookie() {
+    var value = "; " + document.cookie;
+    var parts = value.split("; JWT=");
+    if (parts.length == 2) {
+        return parts.pop().split(";").shift();
+    } else {
+        return false;
+    }
+  },
+
+  checkAuth() {
+    var jwt = localStorage.getItem('id_jwt');
+    if (jwt) {
+      this.user.authenticated = true;
+    } else {
+      jwt = this.getJwtFromCookie();
+      if(jwt) {
+        localStorage.setItem('id_jwt', jwt);
+        this.user.authenticated = true;
+      } else {
+        this.user.authenticated = false;
+      }
+
+    }
+  },
+
+  getAuthHeader() {
+    return {
+      'Authorization': 'Bearer ' + localStorage.getItem('id_jwt')
+    }
+  }
+}


### PR DESCRIPTION
加入auth模块为前端管理jwt。

在其他需要发请求的视图里，只需要import auth，并且通过getAuthHeader来拿到带jwt的header一起发出去就可以了。auth模块在前端app初始化的时候会尝试从cookie里获取jwt，然后放到localstorage里自己管理：

![image](https://user-images.githubusercontent.com/5182462/39103687-3df201c4-467a-11e8-86b2-c13a3ef98eff.png)

以后可以加入jwt的自动refresh功能。