### PR TITLE
增加社交账号显示和解绑的功能

### DIFF
--- a/src/api/users.js
+++ b/src/api/users.js
@@ -65,3 +65,17 @@ export function checkin (userId) {
     method: 'post'
   })
 }
+
+export function getSocialAccounts () {
+  return request({
+    url: '/proxy/rest-auth/socialaccounts/',
+    method: 'get'
+  })
+}
+
+export function disconnectSocialAccount (socialAccountId) {
+  return request({
+    url: '/proxy/rest-auth/socialaccounts/' + socialAccountId + '/disconnect/',
+    method: 'post'
+  })
+}

--- a/src/views/Profile/AccountCombine.vue
+++ b/src/views/Profile/AccountCombine.vue
@@ -1,12 +1,13 @@
 <template>
   <div>
-    <ul class="accnout-list">
+    <ul class="account-list">
       <li v-for="item in providers"
           v-if="item in socialAccounts"
           v-on:click="disconnectSocialAccount(socialAccounts[item].id)"
+          class="connected-account"
           :key="item">
         <span><i class="iconfont">&#xe677;</i> {{item}}</span>
-        <span class="badge badge-success">已绑定</span>
+        <span class="badge badge-success">已绑定（点击解除绑定）</span>
       </li>
       <li v-else :key="item">
         <span><i class="iconfont">&#xe677;</i> {{item}}</span>
@@ -50,12 +51,15 @@ export default {
 }
 </script>
 <style scoped>
-  .accnout-list {
+  .account-list {
     padding: 10px;
   }
-  .accnout-list li {
+  .account-list li {
     height: 45px;
     line-height: 45px;
     border-bottom: 1px solid #ccc;
+  }
+  .account-list li.connected-account {
+    cursor: pointer;
   }
 </style>

--- a/src/views/Profile/AccountCombine.vue
+++ b/src/views/Profile/AccountCombine.vue
@@ -1,23 +1,50 @@
 <template>
   <div>
     <ul class="accnout-list">
-      <li>
-        <span><i class="iconfont">&#xe677;</i> github</span>
+      <li v-for="item in providers"
+          v-if="item in socialAccounts"
+          v-on:click="disconnectSocialAccount(socialAccounts[item].id)"
+          :key="item">
+        <span><i class="iconfont">&#xe677;</i> {{item}}</span>
         <span class="badge badge-success">已绑定</span>
       </li>
-      <li>
-        <span><i class="iconfont">&#xe635;</i> github</span>
+      <li v-else :key="item">
+        <span><i class="iconfont">&#xe677;</i> {{item}}</span>
         <span class="badge badge-info">未绑定</span>
       </li>
     </ul>
   </div>
 </template>
 <script>
+import Vue from 'vue'
+import { getSocialAccounts, disconnectSocialAccount } from '@/api/users'
+
 export default {
   name: 'Account',
   data () {
     return {
-      msg: '账号关联'
+      providers: ['github'], // 我们支持的provider列表
+      socialAccounts: {}
+    }
+  },
+  mounted: function () {
+    this.getSocialAccounts()
+  },
+  methods: {
+    getSocialAccounts () {
+      getSocialAccounts().then(res => {
+        const data = res.data.data
+        const newSocialAccounts = {}
+        for (let accountIndex in data) {
+          newSocialAccounts[data[accountIndex].provider] = data[accountIndex]
+        }
+        Vue.set(this, 'socialAccounts', newSocialAccounts)
+      })
+    },
+    disconnectSocialAccount (socialAccountId) {
+      disconnectSocialAccount(socialAccountId).then(() => {
+        this.getSocialAccounts()
+      })
     }
   }
 }


### PR DESCRIPTION
社交账号显示：
在账号关联页面，如果有已绑定的社交账号，则会显示为“已绑定（点击解除绑定）“，如下图所示：
![image](https://user-images.githubusercontent.com/5182462/46894104-3f992f80-ce41-11e8-9b75-2d3b22c8ac7d.png)
否则会显示为“未绑定”

点击已绑定的账号以后，会解除账号绑定并将状态翻转为未绑定：
![image](https://user-images.githubusercontent.com/5182462/46894123-593a7700-ce41-11e8-9c9a-f5d5f68e0095.png)

重新关联功能内容多一些，我单独开一个分支开发。